### PR TITLE
don't let last scroll position go below 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,10 +113,12 @@ const PeekElement = function(props) {
     const partially =
       childRect.top < 0 && Math.abs(childRect.top) < childRect.height
     const entirely = childRect.top > -1
-    if (lastScrollPosition.current > window.scrollY) {
+    const lastScrollPositionCapped = Math.max(0, lastScrollPosition.current)
+    const scrollTop = Math.max(0, window.scrollY)
+    if (lastScrollPositionCapped > window.scrollY) {
       scrollDirection.current = SCROLLING_UP
     }
-    if (lastScrollPosition.current < window.scrollY) {
+    if (lastScrollPositionCapped < window.scrollY) {
       scrollDirection.current = SCROLLING_DOWN
     }
     if (partially) {


### PR DESCRIPTION
There was an issue where the SCROLLING_DOWN class was being added when dragging down on iPhone at top of page. This is because the iPhone supports negative scrollY values.

This PR resolves this by ignoring negative scrollY values and setting them as 0.